### PR TITLE
fixed issue with importing utils

### DIFF
--- a/doubly_stochastic_dgp/dgp.py
+++ b/doubly_stochastic_dgp/dgp.py
@@ -18,7 +18,7 @@ from GPflow._settings import settings
 
 float_type = settings.dtypes.float_type
 
-from utils import normal_sample, shape_as_list, tile_over_samples
+from .utils import normal_sample, shape_as_list, tile_over_samples
 
 class Layer(Parameterized):
     def __init__(self, kern, q_mu, q_sqrt, Z, mean_function):


### PR DESCRIPTION
Hi @hughsalimbeni 

I had an issue with importing the `dgp` module after I ran the setup. Python was unable to locate the `utils` submodule. I managed to fix it by changing the import statement for `utils` in `dgp.py` to a relative import. So I just wanted to share my fix in case others have the same problem.

Great project by the way! Keep up the good work!

Ayman